### PR TITLE
Update lock.js with bug fix

### DIFF
--- a/addon/authenticators/lock.js
+++ b/addon/authenticators/lock.js
@@ -205,9 +205,9 @@ export default Base.extend({
   },
 
   invalidate: function(/* data */) {
+    var self = this;
     if(this.get('hasRefreshToken')){
       var url = 'https://'+this.get('domain')+'/api/users/'+this.get('userID')+'/refresh_tokens/'+this.get('refreshToken');
-      var self = this;
       return this._makeAuth0Request(url, "DELETE").then(function(){
         return self.beforeExpire();
       });


### PR DESCRIPTION
ensures `var self = this;` is added before if statement preventing undefined this scenario.