### PR TITLE
Added missing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "lock.js"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.3"
+    "ember-cli-babel": "^5.1.3",
+    "ember-router-generator": "^1.1.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.3",
-    "ember-router-generator": "^1.1.1"
+    "ember-router-generator": "^1.1.1",
+    "fs-extra": "^0.26.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
`ember help generate` fails because of a missing dependency in this package.

The scaffold-auth0 blueprint (https://github.com/auth0/auth0-ember-simple-auth/blob/master/blueprints/scaffold-auth0/index.js) depends on `ember-router-generator` and `fs-extra`.

I've added these dependencies to package.json.

