### PR TITLE
Fix license, readme, and package.json info

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Aram Zadikian
+Copyright (c) 2015 Auth0, Inc. <support@auth0.com> (http://auth0.com)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -382,8 +382,14 @@ Remember, you will also need to update your crossOriginWhitelist if you are maki
 
 Written by @brancusi (Aram Zadikian), maintained in part by Auth0. Thanks Aram!
 
+## Issue Reporting
+
+If you have found a bug or if you have a feature request, please report them at this repository issues section. Please do not report security vulnerabilities on the public GitHub issue tracker. The [Responsible Disclosure Program](https://auth0.com/whitehat) details the procedure for disclosing security issues.
+
+## Author
+
+[Auth0](auth0.com)
+
 ## License
 
-auth0-ember-simple-auth by Aram Zadikian. It is released under the MIT License.
-
-__Enjoy!__
+This project is licensed under the MIT license. See the [LICENSE](LICENSE) file for more info.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "build": "ember build",
     "test": "ember try:testall"
   },
+  "author": "Auth0",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/auth0/auth0-ember-simple-auth"


### PR DESCRIPTION
License and readme files must adhere to Auth0 approved standards for
public repos. Also author and license info added to package.json.

Fix https://github.com/auth0/auth0-ember-simple-auth/issues/17