### PR TITLE
Update README instructions to include explicit install of ember-simple-auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If you don't already have an account, go signup at for free: [Auth0](https://aut
 ```bash
 ember new hello-safe-world
 cd hello-safe-world
+ember install ember-simple-auth
 ember install auth0/auth0-ember-simple-auth
 ```
 


### PR DESCRIPTION
Without installing, you'll see 
> Could not find module `ember-simple-auth/authenticators/base` imported from `auth0-ember-simple-auth/authenticators/lock`

In the browser console when `ember-simple-auth` can't find a dependency. I'm _assuming_ it's not declared as a peerDependency because those are awful.

I'm also unsure about which version of `ember-simple-auth` makes sense for Ember 1.x