### PR TITLE
Add missing ember-getowner-polyfill dependency

### DIFF
--- a/examples/ember2-auth0-sample/README.md
+++ b/examples/ember2-auth0-sample/README.md
@@ -4,6 +4,7 @@ This is the seed project to get you started with an ember 2 application that use
 
 ## Running the example
 
+* Set your Auth0 client ID and domain in `config/auth0-variables.js`
 * Install node
 * Install bower
 * Install ember-cli (`npm i -g ember-cli`)

--- a/examples/ember2-auth0-sample/package.json
+++ b/examples/ember2-auth0-sample/package.json
@@ -36,6 +36,7 @@
     "ember-data": "1.13.8",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
+    "ember-getowner-polyfill": "1.0.1",
     "ember-simple-auth": "1.0.1"
   },
   "dependencies": {


### PR DESCRIPTION
Otherwise following the README setup instructions fails with:

```
Error: Could not find module `ember-getowner-polyfill` imported from
`auth0-ember-simple-auth/authenticators/lock`
```