### PR TITLE
Updated lock to 8.3.0 to address security vulnerability

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0",
-    "auth0-lock": "8.2.0",
+    "auth0-lock": "8.3.0",
     "jsrsasign": "4.9.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I received an e-mail today about a critical vulnerability in Auth0 / lock.
This PR updates the dependency on lock in bower.json to use the `8.3.0` version.